### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ https://github.com/comprna/SUPPA/releases/tag/v2.3
 SUPPA works with a command/subcommand structure:
 
 ```
-python3.4 suppa.py subcommand options
-
+suppa.py subcommand options
 ```
 where the subcommand can be one of these five:
 


### PR DESCRIPTION
if suppa was installed using a dependency manager it would just be in the PATH and `python3.4` would break that